### PR TITLE
Feature/updated config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-26
+
+### Added
+- **Consolidated Import Configuration**: New `import` key in `handoff.config.json` replaces the disparate `hubdb_mappings`, `componentJS`, and `componentCSS` top-level keys. Allows skipping entire component types (`element: false`), excluding individual components (`block: { accordion: false }`), and specifying HubDB mappings or per-component JS/CSS overrides within a unified structure.
+- **Auto-Generated Data Source Selector**: HubDB-mapped array fields now automatically receive a "Data Source" choice field offering "Query Builder" or "Manual Data" options. HubSpot visibility rules dynamically show/hide the query builder fields and manual data interface based on the selection—no manual field definitions required in Handoff.
+- **Component Type Filtering**: `fetchAll` and `validateAll` now respect the `import` config, skipping excluded components before validation or build.
+- **Import Resolution Helpers**: New `getComponentImportConfig`, `shouldImportComponent`, and `getHubdbMapping` functions centralize all config lookups.
+
+### Changed
+- **`processHubdbMappings` Signature**: Now accepts a resolved `HubdbMapping` directly instead of reading from the global config internally.
+- **`TranspileContext` Signature**: Constructor accepts a `HubdbMapping` instead of the full `AppConfig` and component ID.
+- **`transpile()` Signature**: Accepts an optional `HubdbMapping` parameter directly.
+- **`HandoffComponent.type`**: Changed from `FieldType` to `ComponentType` for correct component-level type discrimination.
+
+### Removed
+- **`hubdb_mappings`**: Replaced by `import.{type}.{id}` entries with `type: "hubdb"`.
+- **`componentJS` / `componentCSS`**: Replaced by per-component `js` and `css` booleans inside `import`.
+
 ## [0.2.0] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -285,29 +285,65 @@ Validate and build every component. Without `--force`, aborts the entire run if 
 | `moduleJS` | `boolean` | `false` | When `true`, writes per-module compiled JS; when `false`, writes a blank stub |
 | `username` | `string` | `""` | HTTP Basic Auth username (optional) |
 | `password` | `string` | `""` | HTTP Basic Auth password (optional) |
-| `componentCSS` | `string[]` | `[]` | Array of component IDs that should have their own CSS files |
-| `componentJS` | `string[]` | `[]` | Array of component IDs that should have their own JS files |
+| `import` | `object` | *(absent)* | Per-component-type import rules (see below) |
 
-### HubDB Data Mappings
+### Import Configuration
 
-To empower component generic arrays or maps to pull real data securely from HubDB instead of requiring static entries, supply a `hubdb_mappings` mapping on your components:
+The `import` key controls which components are transpiled and how. It replaces the previous `hubdb_mappings`, `componentJS`, and `componentCSS` top-level keys.
+
+Each key under `import` corresponds to a Handoff component type (e.g. `"element"`, `"block"`, `"data"`). The value is either a boolean or an object with per-component overrides:
 
 ```json
 {
-  "hubdb_mappings": {
-    "bar_chart": {
-      "target_property": "data",
-      "mapping_type": "xy"
+  "import": {
+    "element": false,
+    "block": {
+      "accordion": false
     },
-    "category_breakdown_chart": {
-      "target_property": "data",
-      "mapping_type": "multi_series"
+    "data": {
+      "bar_chart": {
+        "type": "hubdb",
+        "target_property": "data",
+        "mapping_type": "xy"
+      },
+      "category_breakdown_chart": {
+        "type": "hubdb",
+        "target_property": "data",
+        "mapping_type": "multi_series"
+      }
     }
   }
 }
 ```
 
-Handoff-HubSpot automatically injects the HubDB HubL lookup configurations directly into the component's output template dynamically overriding standard AST mapping targets when valid query data is returned.\n
+**Semantics:**
+
+| Config value | Effect |
+|---|---|
+| `import.{type}: false` | Skip all components of that type |
+| `import.{type}: true` (or key absent) | Import all components of that type normally |
+| `import.{type}: { id: false }` | Import all of that type except those set to `false` |
+| `import.{type}: { id: { type: "hubdb", ... } }` | Import with HubDB data mapping |
+| `import.{type}: { id: { js: true } }` | Per-component JS override (fetches JS even when `moduleJS` is `false`) |
+| `import.{type}: { id: { css: true } }` | Per-component CSS override (fetches CSS even when `moduleCSS` is `false`) |
+
+When `import` is absent entirely, all components are imported normally.
+
+### HubDB Data Mappings
+
+When a component entry under `import` has `"type": "hubdb"`, the build pipeline treats its `target_property` field as a HubDB-powered data source rather than a static array. Two fields are required:
+
+| Key | Description |
+|-----|-------------|
+| `target_property` | The name of the array/object property in the component schema to map (e.g. `"data"`) |
+| `mapping_type` | Either `"xy"` (two-column x/y data) or `"multi_series"` (multiple named series with categories) |
+
+**What happens at build time:**
+
+1. A **Data Source** choice field is auto-generated with two options: "Query Builder" and "Manual Data" (default). This field is always visible in the HubSpot editor and does not depend on any field defined in Handoff.
+2. A **Query Config** field group is injected, visible only when "Query Builder" is selected. It contains fields for table selection, column mapping, sorting, limits, and a diagnostic toggle.
+3. The **target array field** (e.g. `data`) is annotated with a visibility rule so it only appears when "Manual Data" is selected.
+4. The transpiler rewrites all Handlebars references to the target property as `component_data` and prepends HubL code that queries HubDB when in query mode, falling through to the manual array otherwise.
 
 ---
 

--- a/Specification.md
+++ b/Specification.md
@@ -26,7 +26,7 @@ type HandoffComponent = {
   version: string;      // Semver string, e.g. "1.4.2"
   title: string;        // Human-readable name, e.g. "Hero Banner"
   description: string;  // Short description
-  type: FieldType;      // Top-level component type
+  type: ComponentType;  // Top-level component type (see §1.6)
   preview: string;      // URL to a preview image
   group: string;        // Logical grouping, e.g. "Navigation", "Marketing"
   categories: string[]; // HubSpot category slugs (see §2.1)
@@ -69,7 +69,15 @@ breadcrumb | video_file | video_embed | file
 array | object | menu | search | pagination | hubdbtable
 ```
 
-### 1.4 RulesDefinition
+### 1.4 ComponentType
+
+The top-level type of a Handoff component, used for import filtering (§1.7):
+
+```
+element | block | data
+```
+
+### 1.5 RulesDefinition
 
 ```typescript
 interface RulesDefinition {
@@ -92,7 +100,7 @@ interface RulesDefinition {
 }
 ```
 
-### 1.5 Default Value Shapes by Type
+### 1.6 Default Value Shapes by Type
 
 | Type | Expected default shape |
 |------|------------------------|
@@ -109,11 +117,62 @@ interface RulesDefinition {
 | `menu` | any (passed through) |
 | `array`, `object` | omitted or `null` |
 
+### 1.7 Import Configuration
+
+The `import` key on `AppConfig` controls which components are transpiled and how they are built. It consolidates the former `hubdb_mappings`, `componentJS`, and `componentCSS` top-level keys into a single hierarchical structure.
+
+```typescript
+import?: {
+  [componentType: string]: ImportTypeConfig;
+};
+
+type ImportTypeConfig = boolean | {
+  [componentId: string]: boolean | ComponentImportConfig;
+};
+
+interface ComponentImportConfig {
+  type?: "hubdb";
+  target_property?: string;
+  mapping_type?: "xy" | "multi_series";
+  js?: boolean;
+  css?: boolean;
+}
+
+interface HubdbMapping {
+  target_property: string;
+  mapping_type: "xy" | "multi_series";
+}
+```
+
+**Resolution algorithm** (`getComponentImportConfig(config, componentType, componentId)`):
+
+1. If `config.import` is absent → return `true` (import normally).
+2. Look up `config.import[componentType]`:
+   - `undefined` → return `true`.
+   - `false` → return `null` (skip all components of this type).
+   - `true` → return `true`.
+3. Look up `typeConfig[componentId]`:
+   - `undefined` → return `true`.
+   - `false` → return `null` (skip this component).
+   - `true` → return `true`.
+   - `ComponentImportConfig` object → return the object.
+
+**Derived helpers:**
+
+| Helper | Behavior |
+|--------|----------|
+| `shouldImportComponent(config, type, id)` | Returns `false` when the resolved config is `null`; `true` otherwise. Used by `fetchAll` and `validateAll` to skip excluded components. |
+| `getHubdbMapping(config, type, id)` | Returns a `HubdbMapping` when the resolved config has `type === "hubdb"` with valid `target_property` and `mapping_type`; `null` otherwise. Passed directly to the transpiler and field generator. |
+
+**Per-component JS/CSS resolution:**
+
+When the resolved `ComponentImportConfig` has `js: true`, the build writes the component's own JavaScript even if the global `moduleJS` is `false`. The same applies for `css: true` and `moduleCSS`.
+
 ---
 
 ## 2. Validation Specification
 
-Validation runs before transpilation. A component that fails with one or more **errors** will not be built unless the `--force` flag is passed. **Warnings** are surfaced but do not block the build.
+Validation runs before transpilation. Components excluded by the `import` configuration (§1.7) are skipped entirely during `validateAll`. A component that fails with one or more **errors** will not be built unless the `--force` flag is passed. **Warnings** are surfaced but do not block the build.
 
 ### 2.1 Module-Level Validation
 
@@ -454,8 +513,9 @@ Note the `+1` offset applied to numeric literals when the left operand is `@inde
 
 ### 3.12 HubDB Array Mappings
 
-When a component array field is mapped to HubDB via `handoff.config.json` `hubdb_mappings`, the transpiler interrupts standard arrays compilation.
-Instead, it prepends a generic HubDB row-fetching script using HubL dict capabilities to map data columns. The payload Handlebars expressions for `properties.array_name` are then replaced with the dynamically constructed `component_data` HubDB payload rendering variable.
+When a component array field is mapped to HubDB via the `import` configuration (§1.7), the transpiler interrupts standard array compilation. It reads `target_property` and `mapping_type` from the resolved `HubdbMapping` (passed through the `TranspileContext`), prepends a HubDB row-fetching script using HubL dict capabilities to map data columns, and replaces all Handlebars references to `properties.{target_property}` with the dynamically constructed `component_data` variable.
+
+The `TranspileContext` stores both `hubdbTargetProperty` and `hubdbMappingType` from the resolved mapping.
 
 ### 3.13 Post-Processing
 
@@ -697,7 +757,58 @@ Produces a **group** field (no `occurrence`):
 
 Children are built from `property.properties` with `parentId = key`.
 
-### 4.3 Unrecognized Types
+### 4.3 HubDB Source Field Auto-Generation
+
+When a component has a resolved `HubdbMapping` (§1.7), the field generator calls `processHubdbMappings(fields, hubdbMapping)` after `buildFields`. This function mutates the `fields` array in place:
+
+1. **Locate the target field** — finds the field whose `name` matches `mapping.target_property`. If not found, the function returns early.
+
+2. **Inject a `source` choice field** at the target field's index position:
+
+```json
+{
+  "id": "source",
+  "name": "source",
+  "label": "Data Source",
+  "type": "choice",
+  "display": "select",
+  "choices": [["query", "Query Builder"], ["manual", "Manual Data"]],
+  "default": "manual",
+  "help_text": "Choose how data is provided to this module."
+}
+```
+
+3. **Inject a `query_configs` group field** containing the HubDB query builder fields (table selector, column mappings, sort, limit, and diagnostic toggle). This group has a visibility rule showing it only when `source == "query"`:
+
+```json
+{
+  "visibility": {
+    "controlling_field_path": "source",
+    "controlling_value_regex": "query",
+    "operator": "EQUAL"
+  }
+}
+```
+
+The group's children vary by `mapping_type`:
+- **`xy`**: adds a `y_column` text field for the Y-axis column name.
+- **`multi_series`**: adds a `y_series` repeatable group with `series_name`, `y_column`, and `color` fields.
+
+4. **Gate the target array field** — adds a visibility rule to the original target field so it only appears when `source == "manual"`:
+
+```json
+{
+  "visibility": {
+    "controlling_field_path": "source",
+    "controlling_value_regex": "manual",
+    "operator": "EQUAL"
+  }
+}
+```
+
+The final field order at the injection point is: `source` → `query_configs` → original target field.
+
+### 4.4 Unrecognized Types
 
 Types not listed in §4.2 (`breadcrumb`, `video_file` with unknown sub-types, `file`, `search`, `pagination`, `checkbox`) produce no output and are silently dropped from the `fields.json` array.
 
@@ -720,14 +831,15 @@ The module folder name is derived from the component `id` with all non-alphanume
 
 ### 5.3 `module.css`
 
-- When `config.moduleCSS === true`: the raw `component.css` string
-- When `config.moduleCSS === false`: `/** We are using the core compiled css. This file is blank */`
+- When the resolved `ComponentImportConfig` has `css: true`, OR the global `config.moduleCSS === true`: the raw `component.css` string
+- Otherwise: `/** We are using the core compiled css. This file is blank */`
 
 ### 5.4 `module.js`
 
-- When `config.moduleJS === true` and `component.jsCompiled` is set: the compiled JS bundle
-- When `config.moduleJS === true` and `component.jsCompiled` is absent: `/** This file is blank */`
-- When `config.moduleJS === false`: `/** We are using the core compiled JS. This file is blank */`
+- When the resolved `ComponentImportConfig` has `js: true`, OR the global `config.moduleJS === true`:
+  - If `component.jsCompiled` is set: the compiled JS bundle
+  - If `component.jsCompiled` is absent: `/** This file is blank */`
+- Otherwise: `/** We are using the core compiled JS. This file is blank */`
 
 ### 5.5 `meta.json`
 
@@ -755,8 +867,8 @@ When `component.group === "Navigation"`, `global` is set to `true`.
 
 ### 5.6 `fields.json`
 
-A JSON array produced by `buildFields(component.properties)` as specified in §4. Serialized with 2-space indentation.
+A JSON array produced by `buildFields(component.properties)` as specified in §4. When a `HubdbMapping` is resolved for the component, `processHubdbMappings` (§4.3) is applied to inject source selection and query configuration fields. Serialized with 2-space indentation.
 
 ### 5.7 Write Behavior
 
-Files are written asynchronously. If the target `.module` directory does not exist it is created recursively (`fs.mkdirSync(..., { recursive: true })`). Existing files are overwritten without prompting.
+Components excluded by the `import` configuration (§1.7) are skipped entirely during `fetchAll` — no directory or files are created. For included components, files are written asynchronously. If the target `.module` directory does not exist it is created recursively (`fs.mkdirSync(..., { recursive: true })`). Existing files are overwritten without prompting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "handoff-hubspot",
-  "version": "0.2.0-0",
+  "version": "0.2.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "handoff-hubspot",
-      "version": "0.2.0-0",
+      "version": "0.2.0-1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff-hubspot",
-  "version": "0.2.0-0",
+  "version": "0.2.0-1",
   "description": "A CLI toolchain for fetching handoff components and transpiling them into hubspot modules",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -1,12 +1,30 @@
 import fs from "fs";
 import prompts from "prompts";
+
+export interface ComponentImportConfig {
+  type?: "hubdb";
+  target_property?: string;
+  mapping_type?: "xy" | "multi_series";
+  js?: boolean;
+  css?: boolean;
+}
+
+export interface HubdbMapping {
+  target_property: string;
+  mapping_type: "xy" | "multi_series";
+}
+
+export type ImportTypeConfig = boolean | {
+  [componentId: string]: boolean | ComponentImportConfig;
+};
+
 export interface AppConfig {
   version: string;
   url: string;
   cssPath: string;
   jsPath: string;
-  moduleJS: boolean;  componentJS?: string[];
-  moduleCSS: boolean;  componentCSS?: string[];
+  moduleJS: boolean;
+  moduleCSS: boolean;
   modulesPath: string;
   modulePrefix: string;
   username: string;
@@ -23,13 +41,67 @@ export interface AppConfig {
       };
     };
   };
-  hubdb_mappings?: {
-    [key: string]: {
-      target_property: string;
-      mapping_type: "xy" | "multi_series";
-    };
+  import?: {
+    [componentType: string]: ImportTypeConfig;
   };
 }
+
+/**
+ * Resolve the import config for a specific component.
+ * Returns null (skip this component), true (import normally),
+ * or a ComponentImportConfig object (import with overrides).
+ */
+export const getComponentImportConfig = (
+  config: AppConfig,
+  componentType: string,
+  componentId: string
+): null | true | ComponentImportConfig => {
+  if (!config.import) return true;
+
+  const typeConfig = config.import[componentType];
+
+  if (typeConfig === undefined) return true;
+  if (typeConfig === false) return null;
+  if (typeConfig === true) return true;
+
+  const componentConfig = typeConfig[componentId];
+
+  if (componentConfig === undefined) return true;
+  if (componentConfig === false) return null;
+  if (componentConfig === true) return true;
+
+  return componentConfig;
+};
+
+/**
+ * Whether a component should be imported (not excluded by config).
+ */
+export const shouldImportComponent = (
+  config: AppConfig,
+  componentType: string,
+  componentId: string
+): boolean => {
+  return getComponentImportConfig(config, componentType, componentId) !== null;
+};
+
+/**
+ * Extract a HubDB mapping from the resolved import config, if present.
+ */
+export const getHubdbMapping = (
+  config: AppConfig,
+  componentType: string,
+  componentId: string
+): HubdbMapping | null => {
+  const importCfg = getComponentImportConfig(config, componentType, componentId);
+  if (importCfg === null || importCfg === true) return null;
+  if (importCfg.type === "hubdb" && importCfg.target_property && importCfg.mapping_type) {
+    return {
+      target_property: importCfg.target_property,
+      mapping_type: importCfg.mapping_type,
+    };
+  }
+  return null;
+};
 
 const defaultConfig: AppConfig = {
   version: "0.1.0",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { PropertyDefinition } from "./fields/types.js";
-import { AppConfig } from "./config/command.js";
+import { HubdbMapping } from "./config/command.js";
 
 /**
  * Encapsulates all mutable state for a single transpile() call.
@@ -30,20 +30,17 @@ export class TranspileContext {
   /** When inside a {{#field menu}} block, holds the HubL menu variable name */
   menuContext: string | undefined = undefined;
 
-  readonly config?: AppConfig;
-  readonly componentId?: string;
   readonly hubdbTargetProperty?: string;
+  readonly hubdbMappingType?: "xy" | "multi_series";
 
   constructor(
     properties: { [key: string]: PropertyDefinition },
-    config?: AppConfig,
-    componentId?: string
+    hubdbMapping?: HubdbMapping | null,
   ) {
     this.properties = properties;
-    this.config = config;
-    this.componentId = componentId;
-    if (config?.hubdb_mappings && componentId && config.hubdb_mappings[componentId]) {
-      this.hubdbTargetProperty = config.hubdb_mappings[componentId].target_property;
+    if (hubdbMapping) {
+      this.hubdbTargetProperty = hubdbMapping.target_property;
+      this.hubdbMappingType = hubdbMapping.mapping_type;
     }
   }
 

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -4,7 +4,7 @@ import { fetchComponent, fetchComponentList, fetchComponentJs } from "../index.j
 import transpile from "../transpile.js";
 import * as prettier from "prettier";
 import { HandoffComponent } from "../fields/types.js";
-import { readConfig } from "../config/command.js";
+import { readConfig, getComponentImportConfig, shouldImportComponent, getHubdbMapping } from "../config/command.js";
 import fs from "fs";
 import { buildFields } from "../fields/fields.js";
 import { processHubdbMappings } from "../fields/hubdb.js";
@@ -143,7 +143,10 @@ const buildModule = async (componentId: string, force: boolean) => {
     }
   }
 
-  const template = transpile(component.code, component.properties, config, componentId);
+  const importCfg = getComponentImportConfig(config, component.type, componentId);
+  const hubdbMapping = getHubdbMapping(config, component.type, componentId);
+
+  const template = transpile(component.code, component.properties, hubdbMapping);
   let pretty = template;
   try {
     pretty = await prettier.format(template, {
@@ -180,16 +183,18 @@ const buildModule = async (componentId: string, force: boolean) => {
     "\n\n" +
     pretty;
   writeToModuleFile(pretty, componentId, `module.html`);
+  const useComponentCSS = config.moduleCSS || (typeof importCfg === "object" && importCfg.css);
   let css;
-  if (!config.moduleCSS && (!config.componentCSS || !config.componentCSS.includes(componentId))) {
+  if (!useComponentCSS) {
     css = "/**\n * We are using the core compiled css. This file is blank \n */";
   } else {
     css = component.css;
   }
   writeToModuleFile(css, componentId, `module.css`);
 
+  const useComponentJS = config.moduleJS || (typeof importCfg === "object" && importCfg.js);
   let js;
-  if (!config.moduleJS && (!config.componentJS || !config.componentJS.includes(componentId))) {
+  if (!useComponentJS) {
     js = "/**\n * We are using the core compiled JS. This file is blank \n */";
   } else {
     // attempt to fetch js from the api
@@ -207,7 +212,7 @@ const buildModule = async (componentId: string, force: boolean) => {
     `meta.json`
   );
   const baseFields = buildFields(component.properties);
-  const processedFields = processHubdbMappings(baseFields, config, componentId);
+  const processedFields = processHubdbMappings(baseFields, hubdbMapping);
 
   writeToModuleFile(
     JSON.stringify(processedFields, null, 2),
@@ -220,6 +225,8 @@ const buildModule = async (componentId: string, force: boolean) => {
 
 
 export const fetchAll = async (force: boolean) => {
+  const config = readConfig();
+
   try {
     await validateAll();
   } catch (e) {
@@ -233,8 +240,11 @@ export const fetchAll = async (force: boolean) => {
 
   const data = await fetchComponentList();
   for (const component of data) {
+    if (!shouldImportComponent(config, component.type, component.id)) {
+      console.log(chalk.gray(`\nSkipping ${component.title} (excluded by config)`));
+      continue;
+    }
     console.log(chalk.blue(`\nBuilding ${component.title}`));
-    // validate the component
     try {
       await buildModule(component.id, force);
     } catch (e) {

--- a/src/fields/hubdb.ts
+++ b/src/fields/hubdb.ts
@@ -1,22 +1,18 @@
-import { AppConfig } from "../config/command.js";
+import { HubdbMapping } from "../config/command.js";
 
 /**
  * Mutates the base fields array to inject HubDB mapping specific fields
- * if the component is defined in handoff.config.json
+ * when a resolved HubDB mapping is provided.
  */
 export const processHubdbMappings = (
   fields: any[],
-  config: AppConfig,
-  componentId: string
+  hubdbMapping?: HubdbMapping | null,
 ) => {
-  if (!config.hubdb_mappings || !config.hubdb_mappings[componentId]) {
+  if (!hubdbMapping) {
     return fields;
   }
 
-  const mapping = config.hubdb_mappings[componentId];
-  if (!mapping.target_property || !mapping.mapping_type) {
-    return fields;
-  }
+  const mapping = hubdbMapping;
 
   const targetName = mapping.target_property;
   // Make sure the target property exists in the fields

--- a/src/fields/types.ts
+++ b/src/fields/types.ts
@@ -54,7 +54,7 @@ export type HandoffComponent = {
   version: string;
   title: string;
   description: string;
-  type: FieldType;
+  type: ComponentType;
   preview: string;
   group: string;
   categories: string[];

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -1,6 +1,6 @@
 import Handlebars from "handlebars";
 import { PropertyDefinition } from "./fields/types.js";
-import { AppConfig } from "./config/command.js";
+import { HubdbMapping } from "./config/command.js";
 import { v4 as uuidv4 } from "uuid";
 import chalk from "chalk";
 import { TranspileContext } from "./context.js";
@@ -510,15 +510,14 @@ export const handleProgram = (
 const transpile = (
   code: string,
   props?: { [key: string]: PropertyDefinition },
-  config?: AppConfig,
-  componentId?: string
+  hubdbMapping?: HubdbMapping | null,
 ): string => {
-  const ctx = new TranspileContext(props || {}, config, componentId);
+  const ctx = new TranspileContext(props || {}, hubdbMapping);
   const parsed = Handlebars.parse(code);
   let output = handleProgram(parsed, ctx);
 
-  if (ctx.config && ctx.componentId && ctx.config.hubdb_mappings && ctx.config.hubdb_mappings[ctx.componentId]) {
-      const mapping = ctx.config.hubdb_mappings[ctx.componentId];
+  if (ctx.hubdbTargetProperty && ctx.hubdbMappingType) {
+      const mapping = { target_property: ctx.hubdbTargetProperty, mapping_type: ctx.hubdbMappingType };
       if (mapping.mapping_type === "xy") {
       let xKey = "x";
       let yKey = "y";

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -5,6 +5,7 @@ import {
   PropertyDefinition,
 } from "../fields/types.js";
 import { fetchComponent, fetchComponentList } from "../index.js";
+import { readConfig, shouldImportComponent } from "../config/command.js";
 type Severity = "error" | "warning";
 export interface FieldValidation {
   message: string;
@@ -502,10 +503,14 @@ const validateComponent = async (id: string) => {
 };
 
 export const validateAll = async () => {
+  const config = readConfig();
   const data = await fetchComponentList();
   let errorCount = 0;
   for (let component of data) {
-    // validate the component
+    if (!shouldImportComponent(config, component.type, component.id)) {
+      console.log(chalk.gray(`\nSkipping ${component.id} (excluded by config)`));
+      continue;
+    }
     console.log(chalk.blue(`\nValidating ${component.id} (${component.title})`));
     const full = await fetchComponent(component.id);
     const latest = full;

--- a/tests/hubdb.test.ts
+++ b/tests/hubdb.test.ts
@@ -2,16 +2,13 @@ import { describe, expect, it } from "vitest";
 import transpile from "../src/transpile.js";
 import { buildFields } from "../src/fields/fields.js";
 import { processHubdbMappings } from "../src/fields/hubdb.js";
+import { HubdbMapping } from "../src/config/command.js";
 
 describe("HubDB Integration Mappings", () => {
   it("Should correctly append generic hubdb fields to component JSON when target match occurs", () => {
-    const mockConfig: any = {
-      hubdb_mappings: {
-        "test_component": {
-          target_property: "chart_data",
-          mapping_type: "multi_series",
-        },
-      },
+    const mapping: HubdbMapping = {
+      target_property: "chart_data",
+      mapping_type: "multi_series",
     };
 
     const componentProperties: any = {
@@ -24,7 +21,7 @@ describe("HubDB Integration Mappings", () => {
     };
 
     const baseFields = buildFields(componentProperties);
-    const results = processHubdbMappings(baseFields, mockConfig, "test_component");
+    const results = processHubdbMappings(baseFields, mapping);
 
     expect(results.length).toBe(3);
     expect(results[0].name).toBe("source");
@@ -41,21 +38,16 @@ describe("HubDB Integration Mappings", () => {
     <div id="chart" data-opts='{{#if properties.chart_data}}{{properties.chart_data}}{{else}}{}{{/if}}'></div>
     `;
 
-    const mockConfig: any = {
-      hubdb_mappings: {
-        "test_xy": {
-          target_property: "chart_data",
-          mapping_type: "xy",
-        },
-      },
+    const mapping: HubdbMapping = {
+      target_property: "chart_data",
+      mapping_type: "xy",
     };
 
-    const transpiled = transpile(handlebars, {}, mockConfig, "test_xy");
+    const transpiled = transpile(handlebars, {}, mapping);
 
     expect(transpiled).toContain("{% if component_data %}");
     expect(transpiled).toContain("{{ component_data }}");
 
-    // Expect the appended setup block
     expect(transpiled).toContain("{% set component_data = module.chart_data %}");
     expect(transpiled).toContain("hubdb_table_rows(module.query_configs.hubdb_table");
     expect(transpiled).toContain(`"y": row[y_id]`);
@@ -66,20 +58,15 @@ describe("HubDB Integration Mappings", () => {
     <script>const data = {{#if properties.chart_data}}{{properties.chart_data}}{{else}}{}{{/if}};</script>
     `;
 
-    const mockConfig: any = {
-      hubdb_mappings: {
-        "test_multi": {
-          target_property: "chart_data",
-          mapping_type: "multi_series",
-        },
-      },
+    const mapping: HubdbMapping = {
+      target_property: "chart_data",
+      mapping_type: "multi_series",
     };
 
-    const transpiled = transpile(handlebars, {}, mockConfig, "test_multi");
+    const transpiled = transpile(handlebars, {}, mapping);
 
     expect(transpiled).toContain("const data = {% if component_data %}");    expect(transpiled).toContain("{{ component_data }}");
     
-    // Check for Multi-series generation logic mapped over y_series iterators
     expect(transpiled).toContain("{% for series_cfg in module.query_configs.y_series %}");
     expect(transpiled).toContain(`series_list.append({ "name": series_cfg.series_name, "data": ser_data, "colorKey": series_cfg.color })`);
   });


### PR DESCRIPTION
Changes

- **Consolidated Import Configuration**: New `import` key in `handoff.config.json` replaces the disparate `hubdb_mappings`, `componentJS`, and `componentCSS` top-level keys. Allows skipping entire component types (`element: false`), excluding individual components (`block: { accordion: false }`), and specifying HubDB mappings or per-component JS/CSS overrides within a unified structure.
- **Auto-Generated Data Source Selector**: HubDB-mapped array fields now automatically receive a "Data Source" choice field offering "Query Builder" or "Manual Data" options. HubSpot visibility rules dynamically show/hide the query builder fields and manual data interface based on the selection—no manual field definitions required in Handoff.
- **Component Type Filtering**: `fetchAll` and `validateAll` now respect the `import` config, skipping excluded components before validation or build.
- **Import Resolution Helpers**: New `getComponentImportConfig`, `shouldImportComponent`, and `getHubdbMapping` functions centralize all config lookups.

### Changed
- **`processHubdbMappings` Signature**: Now accepts a resolved `HubdbMapping` directly instead of reading from the global config internally.
- **`TranspileContext` Signature**: Constructor accepts a `HubdbMapping` instead of the full `AppConfig` and component ID.
- **`transpile()` Signature**: Accepts an optional `HubdbMapping` parameter directly.
- **`HandoffComponent.type`**: Changed from `FieldType` to `ComponentType` for correct component-level type discrimination.

### Removed
- **`hubdb_mappings`**: Replaced by `import.{type}.{id}` entries with `type: "hubdb"`.
- **`componentJS` / `componentCSS`**: Replaced by per-component `js` and `css` booleans inside `import`.